### PR TITLE
add jsonnet README and rename env from lycorp to work

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,8 +18,8 @@ claude/.claude/history.jsonl
 *.local
 zsh/.zshrc.local
 
-# LY Corp specific Jsonnet configs (machine-specific)
-jsonnet/*_lycorp*
+# Work-specific Jsonnet configs (machine-specific)
+jsonnet/*_work*
 
 # Personal Claude configuration (user-specific)
 claude/.claude/CLAUDE.personal.md

--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,8 @@ all: sync
 
 REPO_ROOT := $(abspath $(CURDIR))
 
-# Auto-detect lycorp environment by file presence
-OPENCODE_ENV := $(if $(wildcard $(REPO_ROOT)/jsonnet/opencode_lycorp.libsonnet),lycorp,personal)
+# Auto-detect work environment by file presence
+OPENCODE_ENV := $(if $(wildcard $(REPO_ROOT)/jsonnet/opencode_work.libsonnet),work,personal)
 
 define ensure_safe_symlink
 target="$(1)"; source="$(2)"; force_hint="$(3)"; \
@@ -329,7 +329,7 @@ check-syntax:
 	done
 	@echo "Checking Jsonnet files..."
 	@if command -v jsonnet >/dev/null 2>&1; then \
-		for file in $$(find ./jsonnet -name "*.jsonnet" -o -name "*.libsonnet" 2>/dev/null | grep -v '_lycorp'); do \
+		for file in $$(find ./jsonnet -name "*.jsonnet" -o -name "*.libsonnet" 2>/dev/null | grep -v '_work'); do \
 			echo "  Checking $$file"; \
 			jsonnet --tla-str env=personal "$$file" >/dev/null 2>&1 || jsonnet "$$file" >/dev/null 2>&1 || { echo "❌ Syntax error in $$file"; exit 1; }; \
 		done; \

--- a/jsonnet/README.md
+++ b/jsonnet/README.md
@@ -1,0 +1,44 @@
+# Jsonnet Configuration
+
+Renders `~/.config/opencode/opencode.json` from Jsonnet source files.
+
+## Files
+
+| File | Description | Git tracked |
+|------|-------------|-------------|
+| `opencode.jsonnet` | Entry point | Yes |
+| `opencode_models.libsonnet` | Shared model definitions (reasoning variants, GPT/Claude models) | Yes |
+| `opencode_personal.libsonnet` | Personal MCP servers and providers | Yes |
+
+Additional `opencode_*.libsonnet` files can be added for environment-specific config (gitignored).
+
+## Rendering
+
+Prerequisites: `jsonnet` (install via `brew install jsonnet`)
+
+### Personal only (default)
+
+```sh
+jsonnet jsonnet/opencode.jsonnet > ~/.config/opencode/opencode.json
+```
+
+### With environment-specific config
+
+```sh
+jsonnet --tla-str env=work jsonnet/opencode.jsonnet > ~/.config/opencode/opencode.json
+```
+
+### Preview without writing
+
+```sh
+jsonnet jsonnet/opencode.jsonnet
+```
+
+## Via Makefile
+
+`make sync-opencode` auto-detects the environment based on which libsonnet files are present.
+
+```sh
+make sync-opencode        # install (fails if opencode.json already differs)
+make sync-opencode-force  # overwrite existing config
+```

--- a/jsonnet/opencode.jsonnet
+++ b/jsonnet/opencode.jsonnet
@@ -3,21 +3,21 @@
 //
 // Usage:
 //   Personal only:  jsonnet opencode.jsonnet
-//   With LY Corp:   jsonnet --tla-str env=lycorp opencode.jsonnet
+//   With work:      jsonnet --tla-str env=work opencode.jsonnet
 function(env='personal')
-  local isLycorp = env == 'lycorp';
+  local isWork = env == 'work';
 
   local personal = import 'opencode_personal.libsonnet';
-  local corporate = import 'opencode_lycorp.libsonnet';
+  local work = import 'opencode_work.libsonnet';
 
   {
     '$schema': 'https://opencode.ai/config.json',
     theme: 'system',
-    plugin: if isLycorp then ['@devtheops/opencode-plugin-otel'] else [],
+    plugin: if isWork then ['@devtheops/opencode-plugin-otel'] else [],
     enabled_providers: personal.enabled_providers
-                       + (if isLycorp then corporate.enabled_providers else []),
+                       + (if isWork then work.enabled_providers else []),
     provider: personal.provider
-              + (if isLycorp then corporate.provider else {}),
+              + (if isWork then work.provider else {}),
     mcp: personal.mcp
-         + (if isLycorp then corporate.mcp else {}),
+         + (if isWork then work.mcp else {}),
   }


### PR DESCRIPTION
Generalize environment naming to avoid exposing employer in public git history. Rename opencode_lycorp.libsonnet to opencode_work.libsonnet, update all references in Makefile, .gitignore, and opencode.jsonnet. Add jsonnet/README.md with rendering instructions.