### PR TITLE
feat(tmux): manage Ghostty-compatible XDG configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y stow
+        sudo apt-get install -y stow tmux
         # Install luacheck via luarocks (requires Lua setup first)
         luarocks install luacheck
 
@@ -45,6 +45,9 @@ jobs:
 
     - name: Run safety regression tests
       run: make test-safety
+
+    - name: Run tmux runtime tests
+      run: make test-tmux-config
 
     - name: Test Neovim stow functionality
       run: |

--- a/Makefile
+++ b/Makefile
@@ -5,10 +5,6 @@ all: sync
 SHELL := /bin/bash
 
 REPO_ROOT := $(abspath $(CURDIR))
-TMUX_DATA_HOME = $(if $(strip $(XDG_DATA_HOME)),$(XDG_DATA_HOME),$(HOME)/.local/share)
-TMUX_PLUGIN_DIR = $(TMUX_DATA_HOME)/tmux/plugins
-TPM_DIR = $(TMUX_PLUGIN_DIR)/tpm
-TPM_REPOSITORY ?= https://github.com/tmux-plugins/tpm
 
 define ensure_safe_symlink
 target="$(1)"; source="$(2)"; force_hint="$(3)"; \
@@ -43,15 +39,9 @@ elif [ -e "$$target" ] && [ "$$quiet_non_symlink" != "quiet" ]; then \
 fi
 endef
 
-# Shared prerequisites
+# Shared prerequisite
 require-stow:
 	@command -v stow >/dev/null 2>&1 || { echo "❌ stow is not installed. Please install it first."; exit 1; }
-
-require-git:
-	@command -v git >/dev/null 2>&1 || { echo "❌ git is not installed. Please install it first."; exit 1; }
-
-require-tmux:
-	@command -v tmux >/dev/null 2>&1 || { echo "❌ tmux is not installed. Please install it first."; exit 1; }
 
 # Install all dotfiles (removed automatic installation)
 sync:
@@ -118,43 +108,6 @@ sync-tmux: require-stow
 	@echo "🧩 Installing tmux configuration..."
 	stow -t ~ tmux
 	@echo "✅ tmux configuration installed"
-	@$(MAKE) --no-print-directory check-tmux-deps
-
-check-tmux-deps:
-	@if command -v tmux >/dev/null 2>&1; then \
-		echo "✅ tmux is installed"; \
-	else \
-		echo "⚠️  tmux is not installed; the configuration was linked but cannot be used yet"; \
-	fi
-	@if [ -x "$(TPM_DIR)/tpm" ]; then \
-		echo "✅ TPM is installed at $(TPM_DIR)"; \
-	else \
-		echo "⚠️  TPM is not installed at $(TPM_DIR)"; \
-		echo "   Run: make install-tmux-plugins"; \
-	fi
-
-install-tmux-plugins: require-git require-tmux
-	@if [ ! -f "$(HOME)/.config/tmux/tmux.conf" ]; then \
-		echo "❌ ~/.config/tmux/tmux.conf is not installed"; \
-		echo "   Run: make sync-tmux"; \
-		exit 1; \
-	fi
-	@mkdir -p "$(TMUX_PLUGIN_DIR)"
-	@if [ ! -e "$(TPM_DIR)" ]; then \
-		echo "📦 Installing TPM into $(TPM_DIR)..."; \
-		git clone --depth 1 "$(TPM_REPOSITORY)" "$(TPM_DIR)"; \
-	elif [ ! -x "$(TPM_DIR)/tpm" ]; then \
-		echo "❌ $(TPM_DIR) exists but is not a valid TPM installation"; \
-		exit 1; \
-	else \
-		echo "✅ TPM is already installed at $(TPM_DIR)"; \
-	fi
-	@if [ ! -x "$(TPM_DIR)/bin/install_plugins" ]; then \
-		echo "❌ TPM plugin installer is unavailable: $(TPM_DIR)/bin/install_plugins"; \
-		exit 1; \
-	fi
-	@"$(TPM_DIR)/bin/install_plugins"
-	@echo "✅ tmux plugins installed"
 
 # Install Aerospace configuration (includes Borders)
 sync-aerospace: require-stow
@@ -264,4 +217,4 @@ lint:
 	@command -v luacheck >/dev/null 2>&1 && luacheck nvim/.config/nvim/lua/ nvim/.config/nvim/init.lua || echo "⚠️  luacheck not found, skipping Lua linting"
 	@echo "✅ Linting completed"
 
-.PHONY: all require-stow require-git require-tmux clean clean-force clean-ghostty clean-neovim clean-zsh clean-tig clean-tmux clean-aerospace sync sync-ghostty sync-ghostty-linux sync-ghostty-linux-force sync-neovim sync-zsh sync-tig sync-tmux check-tmux-deps install-tmux-plugins sync-aerospace test test-safety test-sync-smoke test-tmux-config check-syntax lint
+.PHONY: all require-stow clean clean-force clean-ghostty clean-neovim clean-zsh clean-tig clean-tmux clean-aerospace sync sync-ghostty sync-ghostty-linux sync-ghostty-linux-force sync-neovim sync-zsh sync-tig sync-tmux sync-aerospace test test-safety test-sync-smoke test-tmux-config check-syntax lint

--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,7 @@ sync:
 	@echo "  make sync-neovim        - Install Neovim configuration"
 	@echo "  make sync-zsh           - Install Zsh configuration"
 	@echo "  make sync-tig           - Install Tig configuration"
+	@echo "  make sync-tmux          - Install tmux configuration"
 	@echo "  make sync-aerospace     - Install Aerospace configuration"
 
 # Install Ghostty configuration
@@ -95,6 +96,17 @@ sync-tig: require-stow
 	stow -t ~ tig
 	@echo "✅ Tig configuration installed"
 
+# Install tmux configuration
+sync-tmux: require-stow
+	@if [ -e ~/.tmux.conf ] || [ -L ~/.tmux.conf ]; then \
+		echo "❌ ~/.tmux.conf takes precedence over ~/.config/tmux/tmux.conf"; \
+		echo "   Move or remove it before installing this configuration"; \
+		exit 1; \
+	fi
+	@echo "🧩 Installing tmux configuration..."
+	stow -t ~ tmux
+	@echo "✅ tmux configuration installed"
+
 # Install Aerospace configuration (includes Borders)
 sync-aerospace: require-stow
 	@echo "🚀 Installing Aerospace configuration..."
@@ -112,6 +124,7 @@ clean:
 	@echo "  - ~/.config/aerospace/aerospace.toml"
 	@echo "  - ~/.config/borders/bordersrc"
 	@echo "  - ~/.tigrc"
+	@echo "  - ~/.config/tmux/"
 	@echo "  - ~/.zshrc, ~/.p10k.zsh"
 	@echo ""
 	@read -p "Are you sure? [y/N] " -n 1 -r; \
@@ -127,6 +140,7 @@ clean-force:
 	@echo "🧹 Removing all configurations..."
 	@$(MAKE) clean-neovim
 	@$(MAKE) clean-tig
+	@$(MAKE) clean-tmux
 	@$(MAKE) clean-zsh
 	@$(MAKE) clean-ghostty
 	@$(MAKE) clean-aerospace
@@ -143,6 +157,11 @@ clean-tig:
 	@echo "🧹 Removing Tig configuration..."
 	@command -v stow >/dev/null 2>&1 && stow -D -t ~ tig || { $(call remove_managed_path,$${HOME}/.tigrc,$(REPO_ROOT)/tig/.tigrc); }
 	@echo "✅ Tig configuration removed"
+
+clean-tmux:
+	@echo "🧹 Removing tmux configuration..."
+	@command -v stow >/dev/null 2>&1 && stow -D -t ~ tmux || { $(call remove_managed_path,$${HOME}/.config/tmux,$(REPO_ROOT)/tmux/.config/tmux); $(call remove_managed_path,$${HOME}/.config/tmux/tmux.conf,$(REPO_ROOT)/tmux/.config/tmux/tmux.conf); }
+	@echo "✅ tmux configuration removed"
 
 clean-neovim:
 	@echo "🧹 Removing Neovim configuration..."
@@ -193,4 +212,4 @@ lint:
 	@command -v luacheck >/dev/null 2>&1 && luacheck nvim/.config/nvim/lua/ nvim/.config/nvim/init.lua || echo "⚠️  luacheck not found, skipping Lua linting"
 	@echo "✅ Linting completed"
 
-.PHONY: all require-stow clean clean-force clean-ghostty clean-neovim clean-zsh clean-tig clean-aerospace sync sync-ghostty sync-ghostty-linux sync-ghostty-linux-force sync-neovim sync-zsh sync-tig sync-aerospace test test-safety test-sync-smoke check-syntax lint
+.PHONY: all require-stow clean clean-force clean-ghostty clean-neovim clean-zsh clean-tig clean-tmux clean-aerospace sync sync-ghostty sync-ghostty-linux sync-ghostty-linux-force sync-neovim sync-zsh sync-tig sync-tmux sync-aerospace test test-safety test-sync-smoke check-syntax lint

--- a/Makefile
+++ b/Makefile
@@ -180,7 +180,7 @@ clean-aerospace:
 	@echo "✅ Borders configuration removed"
 
 # Test commands
-test: check-syntax lint test-safety test-sync-smoke
+test: check-syntax lint test-safety test-sync-smoke test-tmux-config
 	@echo "✅ All checks passed!"
 
 test-safety:
@@ -188,6 +188,9 @@ test-safety:
 
 test-sync-smoke:
 	@bash "./test_sync_smoke.sh"
+
+test-tmux-config:
+	@bash "./test_tmux_config.sh"
 
 # Check syntax of configuration files
 check-syntax:
@@ -212,4 +215,4 @@ lint:
 	@command -v luacheck >/dev/null 2>&1 && luacheck nvim/.config/nvim/lua/ nvim/.config/nvim/init.lua || echo "⚠️  luacheck not found, skipping Lua linting"
 	@echo "✅ Linting completed"
 
-.PHONY: all require-stow clean clean-force clean-ghostty clean-neovim clean-zsh clean-tig clean-tmux clean-aerospace sync sync-ghostty sync-ghostty-linux sync-ghostty-linux-force sync-neovim sync-zsh sync-tig sync-tmux sync-aerospace test test-safety test-sync-smoke check-syntax lint
+.PHONY: all require-stow clean clean-force clean-ghostty clean-neovim clean-zsh clean-tig clean-tmux clean-aerospace sync sync-ghostty sync-ghostty-linux sync-ghostty-linux-force sync-neovim sync-zsh sync-tig sync-tmux sync-aerospace test test-safety test-sync-smoke test-tmux-config check-syntax lint

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,10 @@ all: sync
 SHELL := /bin/bash
 
 REPO_ROOT := $(abspath $(CURDIR))
+TMUX_DATA_HOME = $(if $(strip $(XDG_DATA_HOME)),$(XDG_DATA_HOME),$(HOME)/.local/share)
+TMUX_PLUGIN_DIR = $(TMUX_DATA_HOME)/tmux/plugins
+TPM_DIR = $(TMUX_PLUGIN_DIR)/tpm
+TPM_REPOSITORY ?= https://github.com/tmux-plugins/tpm
 
 define ensure_safe_symlink
 target="$(1)"; source="$(2)"; force_hint="$(3)"; \
@@ -39,9 +43,15 @@ elif [ -e "$$target" ] && [ "$$quiet_non_symlink" != "quiet" ]; then \
 fi
 endef
 
-# Shared prerequisite
+# Shared prerequisites
 require-stow:
 	@command -v stow >/dev/null 2>&1 || { echo "❌ stow is not installed. Please install it first."; exit 1; }
+
+require-git:
+	@command -v git >/dev/null 2>&1 || { echo "❌ git is not installed. Please install it first."; exit 1; }
+
+require-tmux:
+	@command -v tmux >/dev/null 2>&1 || { echo "❌ tmux is not installed. Please install it first."; exit 1; }
 
 # Install all dotfiles (removed automatic installation)
 sync:
@@ -108,6 +118,43 @@ sync-tmux: require-stow
 	@echo "🧩 Installing tmux configuration..."
 	stow -t ~ tmux
 	@echo "✅ tmux configuration installed"
+	@$(MAKE) --no-print-directory check-tmux-deps
+
+check-tmux-deps:
+	@if command -v tmux >/dev/null 2>&1; then \
+		echo "✅ tmux is installed"; \
+	else \
+		echo "⚠️  tmux is not installed; the configuration was linked but cannot be used yet"; \
+	fi
+	@if [ -x "$(TPM_DIR)/tpm" ]; then \
+		echo "✅ TPM is installed at $(TPM_DIR)"; \
+	else \
+		echo "⚠️  TPM is not installed at $(TPM_DIR)"; \
+		echo "   Run: make install-tmux-plugins"; \
+	fi
+
+install-tmux-plugins: require-git require-tmux
+	@if [ ! -f "$(HOME)/.config/tmux/tmux.conf" ]; then \
+		echo "❌ ~/.config/tmux/tmux.conf is not installed"; \
+		echo "   Run: make sync-tmux"; \
+		exit 1; \
+	fi
+	@mkdir -p "$(TMUX_PLUGIN_DIR)"
+	@if [ ! -e "$(TPM_DIR)" ]; then \
+		echo "📦 Installing TPM into $(TPM_DIR)..."; \
+		git clone --depth 1 "$(TPM_REPOSITORY)" "$(TPM_DIR)"; \
+	elif [ ! -x "$(TPM_DIR)/tpm" ]; then \
+		echo "❌ $(TPM_DIR) exists but is not a valid TPM installation"; \
+		exit 1; \
+	else \
+		echo "✅ TPM is already installed at $(TPM_DIR)"; \
+	fi
+	@if [ ! -x "$(TPM_DIR)/bin/install_plugins" ]; then \
+		echo "❌ TPM plugin installer is unavailable: $(TPM_DIR)/bin/install_plugins"; \
+		exit 1; \
+	fi
+	@"$(TPM_DIR)/bin/install_plugins"
+	@echo "✅ tmux plugins installed"
 
 # Install Aerospace configuration (includes Borders)
 sync-aerospace: require-stow
@@ -217,4 +264,4 @@ lint:
 	@command -v luacheck >/dev/null 2>&1 && luacheck nvim/.config/nvim/lua/ nvim/.config/nvim/init.lua || echo "⚠️  luacheck not found, skipping Lua linting"
 	@echo "✅ Linting completed"
 
-.PHONY: all require-stow clean clean-force clean-ghostty clean-neovim clean-zsh clean-tig clean-tmux clean-aerospace sync sync-ghostty sync-ghostty-linux sync-ghostty-linux-force sync-neovim sync-zsh sync-tig sync-tmux sync-aerospace test test-safety test-sync-smoke test-tmux-config check-syntax lint
+.PHONY: all require-stow require-git require-tmux clean clean-force clean-ghostty clean-neovim clean-zsh clean-tig clean-tmux clean-aerospace sync sync-ghostty sync-ghostty-linux sync-ghostty-linux-force sync-neovim sync-zsh sync-tig sync-tmux check-tmux-deps install-tmux-plugins sync-aerospace test test-safety test-sync-smoke test-tmux-config check-syntax lint

--- a/Makefile
+++ b/Makefile
@@ -24,15 +24,17 @@ fi
 endef
 
 define remove_managed_path
-target="$(1)"; source="$(2)"; \
+target="$(1)"; source="$(2)"; quiet_non_symlink="$(3)"; \
 if [ -L "$$target" ]; then \
 	current="$$(readlink "$$target")"; \
-	if [ "$$current" = "$$source" ]; then \
+	resolved_target="$$(realpath "$$target" 2>/dev/null || true)"; \
+	resolved_source="$$(realpath "$$source" 2>/dev/null || true)"; \
+	if [ -n "$$resolved_source" ] && [ "$$resolved_target" = "$$resolved_source" ]; then \
 		rm -f "$$target"; \
 	else \
 		echo "⚠️  Skipping unmanaged symlink $$target -> $$current"; \
 	fi; \
-elif [ -e "$$target" ]; then \
+elif [ -e "$$target" ] && [ "$$quiet_non_symlink" != "quiet" ]; then \
 	echo "⚠️  Skipping unmanaged path $$target"; \
 fi
 endef
@@ -160,7 +162,7 @@ clean-tig:
 
 clean-tmux:
 	@echo "🧹 Removing tmux configuration..."
-	@command -v stow >/dev/null 2>&1 && stow -D -t ~ tmux || { $(call remove_managed_path,$${HOME}/.config/tmux,$(REPO_ROOT)/tmux/.config/tmux); $(call remove_managed_path,$${HOME}/.config/tmux/tmux.conf,$(REPO_ROOT)/tmux/.config/tmux/tmux.conf); }
+	@command -v stow >/dev/null 2>&1 && stow -D -t ~ tmux || { $(call remove_managed_path,$${HOME}/.config,$(REPO_ROOT)/tmux/.config,quiet); $(call remove_managed_path,$${HOME}/.config/tmux,$(REPO_ROOT)/tmux/.config/tmux); $(call remove_managed_path,$${HOME}/.config/tmux/tmux.conf,$(REPO_ROOT)/tmux/.config/tmux/tmux.conf); }
 	@echo "✅ tmux configuration removed"
 
 clean-neovim:

--- a/README.md
+++ b/README.md
@@ -39,15 +39,17 @@ make test
 make clean
 ```
 
-- `make test` runs syntax checks, linting, safety regression tests, and sync smoke tests.
+- `make test` runs syntax checks, linting, safety regression tests, sync smoke tests, and isolated tmux runtime checks.
 - `make clean` removes repo-managed symlinks and generated files while preserving unmanaged local files.
 
 ## tmux Plugin Setup
 
-The tmux config is tracked in this repository, while TPM and its plugins live under the XDG data directory:
+The tmux config is tracked in this repository, while TPM and its plugins live under `${XDG_DATA_HOME:-$HOME/.local/share}/tmux/plugins`:
 
 ```bash
-git clone https://github.com/tmux-plugins/tpm ~/.local/share/tmux/plugins/tpm
+TMUX_PLUGIN_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/tmux/plugins"
+mkdir -p "$TMUX_PLUGIN_DIR"
+git clone https://github.com/tmux-plugins/tpm "$TMUX_PLUGIN_DIR/tpm"
 make sync-tmux
 ```
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Install the tmux config with:
 make sync-tmux
 ```
 
-The configuration uses native tmux and Ghostty features and has no plugin-manager dependency.
+The configuration uses native tmux and Ghostty features and has no plugin-manager dependency. Ghostty remains the outer terminal and sets `TERM=xterm-ghostty`, while applications inside tmux use `TERM=tmux-256color`, following the [Ghostty terminfo documentation](https://ghostty.org/docs/help/terminfo) and [tmux FAQ](https://github.com/tmux/tmux/wiki/FAQ). Ghostty's terminfo already advertises its capabilities to tmux, so no terminal override is needed.
 
 ## Neovim Plugin Sync
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ make sync
 make sync-zsh
 make sync-neovim
 make sync-ghostty
+make sync-tmux
 ```
 
 Most sync targets fail fast if the destination already contains unmanaged files or symlinks.
@@ -29,6 +30,7 @@ make sync-zsh           # Zsh shell configuration
 make sync-tig           # Tig Git interface
 make sync-ghostty       # Ghostty terminal (macOS)
 make sync-ghostty-linux # Ghostty terminal (Linux)
+make sync-tmux          # tmux configuration
 make sync-aerospace     # Aerospace window manager + Borders (macOS)
 
 make sync-ghostty-linux-force
@@ -57,6 +59,7 @@ Use restore here, not update: `restore` matches your local plugins to `lazy-lock
 - `nvim/` - Neovim configuration
 - `zsh/` - Zsh shell configuration
 - `tig/` - Tig configuration
+- `tmux/` - tmux configuration
 - `ghostty/` - Ghostty config for macOS
 - `ghostty-linux/` - Ghostty config for Linux, including `custom.conf`
 - `aerospace/`, `borders/` - macOS window management

--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ make sync-tig           # Tig Git interface
 make sync-ghostty       # Ghostty terminal (macOS)
 make sync-ghostty-linux # Ghostty terminal (Linux)
 make sync-tmux          # tmux configuration
-make install-tmux-plugins # TPM and declared tmux plugins
 make sync-aerospace     # Aerospace window manager + Borders (macOS)
 
 make sync-ghostty-linux-force
@@ -43,16 +42,15 @@ make clean
 - `make test` runs syntax checks, linting, safety regression tests, sync smoke tests, and isolated tmux runtime checks.
 - `make clean` removes repo-managed symlinks and generated files while preserving unmanaged local files.
 
-## tmux Plugin Setup
+## tmux Setup
 
-The tmux config is tracked in this repository, while TPM and its plugins live under `${XDG_DATA_HOME:-$HOME/.local/share}/tmux/plugins`:
+Install the tmux config with:
 
 ```bash
 make sync-tmux
-make install-tmux-plugins
 ```
 
-`sync-tmux` checks for tmux and TPM but only warns when they are missing, so the config can still be linked in a clean environment. The explicit `install-tmux-plugins` target clones TPM and installs the plugins declared in `tmux.conf`; it performs network access and therefore is not run automatically. After TPM is installed, `Ctrl-Space I` remains available for installing newly declared plugins from inside tmux.
+The configuration uses native tmux and Ghostty features and has no plugin-manager dependency.
 
 ## Neovim Plugin Sync
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ make sync-tig           # Tig Git interface
 make sync-ghostty       # Ghostty terminal (macOS)
 make sync-ghostty-linux # Ghostty terminal (Linux)
 make sync-tmux          # tmux configuration
+make install-tmux-plugins # TPM and declared tmux plugins
 make sync-aerospace     # Aerospace window manager + Borders (macOS)
 
 make sync-ghostty-linux-force
@@ -47,13 +48,11 @@ make clean
 The tmux config is tracked in this repository, while TPM and its plugins live under `${XDG_DATA_HOME:-$HOME/.local/share}/tmux/plugins`:
 
 ```bash
-TMUX_PLUGIN_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/tmux/plugins"
-mkdir -p "$TMUX_PLUGIN_DIR"
-git clone https://github.com/tmux-plugins/tpm "$TMUX_PLUGIN_DIR/tpm"
 make sync-tmux
+make install-tmux-plugins
 ```
 
-Start tmux, then press `Ctrl-Space I` to install the plugins declared in `tmux.conf`.
+`sync-tmux` checks for tmux and TPM but only warns when they are missing, so the config can still be linked in a clean environment. The explicit `install-tmux-plugins` target clones TPM and installs the plugins declared in `tmux.conf`; it performs network access and therefore is not run automatically. After TPM is installed, `Ctrl-Space I` remains available for installing newly declared plugins from inside tmux.
 
 ## Neovim Plugin Sync
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,17 @@ make clean
 - `make test` runs syntax checks, linting, safety regression tests, and sync smoke tests.
 - `make clean` removes repo-managed symlinks and generated files while preserving unmanaged local files.
 
+## tmux Plugin Setup
+
+The tmux config is tracked in this repository, while TPM and its plugins live under the XDG data directory:
+
+```bash
+git clone https://github.com/tmux-plugins/tpm ~/.local/share/tmux/plugins/tpm
+make sync-tmux
+```
+
+Start tmux, then press `Ctrl-Space I` to install the plugins declared in `tmux.conf`.
+
 ## Neovim Plugin Sync
 
 When the automated lazy.nvim lockfile PR is merged, pull the repo and then sync your local plugin installs to the updated lockfile:
@@ -93,6 +104,7 @@ Essential:
 - Git
 - Make
 - GNU Stow
+- tmux
 - Neovim (recent version; current config uses modern built-in LSP APIs)
 - Node.js
 
@@ -100,7 +112,7 @@ Optional:
 - Python 3, Go
 - ripgrep, bat, eza, zoxide, fzf
 - bun
-- alacritty
+- Ghostty
 
 ## License
 

--- a/test_makefile_safety.sh
+++ b/test_makefile_safety.sh
@@ -25,6 +25,13 @@ assert_dir_exists() {
 	fi
 }
 
+assert_path_absent() {
+	if [ -e "$1" ] || [ -L "$1" ]; then
+		printf 'Expected path to be absent: %s\n' "$1" >&2
+		exit 1
+	fi
+}
+
 assert_contains() {
 	local file="$1"
 	local expected="$2"
@@ -46,6 +53,21 @@ assert_symlink_target() {
 
 	if [ "$(readlink "$path")" != "$expected" ]; then
 		printf 'Expected %s to point to %s\n' "$path" "$expected" >&2
+		exit 1
+	fi
+}
+
+assert_symlink_resolves_to() {
+	local path="$1"
+	local expected="$2"
+
+	if [ ! -L "$path" ]; then
+		printf 'Expected symlink: %s\n' "$path" >&2
+		exit 1
+	fi
+
+	if [ "$(realpath "$path")" != "$expected" ]; then
+		printf 'Expected %s to resolve to %s\n' "$path" "$expected" >&2
 		exit 1
 	fi
 }
@@ -155,6 +177,31 @@ test_clean_tmux_preserves_unmanaged_config_without_stow() {
 	assert_contains "$home_dir/.config/tmux/tmux.conf" 'keep me'
 }
 
+test_clean_tmux_removes_relative_stow_link_without_stow() {
+	local home_dir
+	home_dir=$(mktemp -d)
+	trap '[ -n "${home_dir-}" ] && rm -rf "$home_dir"' RETURN
+
+	mkdir -p "$home_dir/.config"
+	HOME="$home_dir" stow -t "$home_dir" tmux
+	assert_file_exists "$home_dir/.config/tmux/tmux.conf"
+
+	PATH="/usr/bin:/bin" HOME="$home_dir" make clean-tmux >"$TEST_OUTPUT" 2>&1
+	assert_path_absent "$home_dir/.config/tmux"
+}
+
+test_clean_tmux_removes_folded_config_link_without_stow() {
+	local home_dir
+	home_dir=$(mktemp -d)
+	trap '[ -n "${home_dir-}" ] && rm -rf "$home_dir"' RETURN
+
+	HOME="$home_dir" stow -t "$home_dir" tmux
+	assert_symlink_resolves_to "$home_dir/.config" "$REPO_ROOT/tmux/.config"
+
+	PATH="/usr/bin:/bin" HOME="$home_dir" make clean-tmux >"$TEST_OUTPUT" 2>&1
+	assert_path_absent "$home_dir/.config"
+}
+
 main() {
 	cd "$REPO_ROOT"
 	test_sync_ghostty_linux_preserves_existing_custom_conf
@@ -164,6 +211,8 @@ main() {
 	test_clean_ghostty_preserves_unmanaged_custom_conf_without_stow
 	test_sync_tmux_rejects_legacy_config
 	test_clean_tmux_preserves_unmanaged_config_without_stow
+	test_clean_tmux_removes_relative_stow_link_without_stow
+	test_clean_tmux_removes_folded_config_link_without_stow
 }
 
 main "$@"

--- a/test_makefile_safety.sh
+++ b/test_makefile_safety.sh
@@ -164,6 +164,56 @@ test_sync_tmux_rejects_legacy_config() {
 	assert_contains "$home_dir/.tmux.conf" 'keep me'
 }
 
+test_sync_tmux_warns_when_tpm_is_missing() {
+	local home_dir xdg_data_home
+	home_dir=$(mktemp -d)
+	xdg_data_home="$home_dir/xdg-data"
+	trap '[ -n "${home_dir-}" ] && rm -rf "$home_dir"' RETURN
+
+	HOME="$home_dir" XDG_DATA_HOME="$xdg_data_home" make sync-tmux >"$TEST_OUTPUT" 2>&1
+
+	assert_contains "$TEST_OUTPUT" 'TPM is not installed'
+	assert_contains "$TEST_OUTPUT" "$xdg_data_home/tmux/plugins/tpm"
+	assert_contains "$TEST_OUTPUT" 'make install-tmux-plugins'
+	assert_file_exists "$home_dir/.config/tmux/tmux.conf"
+}
+
+test_install_tmux_plugins_bootstraps_tpm() {
+	local home_dir xdg_data_home fake_tpm_repo plugin_dir
+	home_dir=$(mktemp -d)
+	xdg_data_home="$home_dir/xdg-data"
+	fake_tpm_repo=$(mktemp -d)
+	plugin_dir="$xdg_data_home/tmux/plugins"
+	trap '[ -n "${home_dir-}" ] && rm -rf "$home_dir"; [ -n "${fake_tpm_repo-}" ] && rm -rf "$fake_tpm_repo"' RETURN
+
+	mkdir -p "$fake_tpm_repo/bin"
+	cat >"$fake_tpm_repo/tpm" <<'EOF'
+#!/bin/bash
+exit 0
+EOF
+	cat >"$fake_tpm_repo/bin/install_plugins" <<'EOF'
+#!/bin/bash
+set -euo pipefail
+config="${XDG_CONFIG_HOME:-$HOME/.config}/tmux/tmux.conf"
+plugin_dir="${XDG_DATA_HOME:-$HOME/.local/share}/tmux/plugins/tmux-open"
+test -f "$config"
+mkdir -p "$plugin_dir"
+printf 'installed\n' >"$plugin_dir/.installed-by-test"
+EOF
+	chmod +x "$fake_tpm_repo/tpm" "$fake_tpm_repo/bin/install_plugins"
+	git -C "$fake_tpm_repo" init -q
+	git -C "$fake_tpm_repo" add tpm bin/install_plugins
+	git -C "$fake_tpm_repo" -c user.name='Dotfiles Test' -c user.email='test@example.com' commit -qm 'test fixture'
+
+	HOME="$home_dir" XDG_DATA_HOME="$xdg_data_home" make sync-tmux >"$TEST_OUTPUT" 2>&1
+	HOME="$home_dir" XDG_DATA_HOME="$xdg_data_home" make \
+		TPM_REPOSITORY="$fake_tpm_repo" install-tmux-plugins >"$TEST_OUTPUT" 2>&1
+
+	assert_file_exists "$plugin_dir/tpm/tpm"
+	assert_file_exists "$plugin_dir/tmux-open/.installed-by-test"
+	assert_contains "$TEST_OUTPUT" 'tmux plugins installed'
+}
+
 test_clean_tmux_preserves_unmanaged_config_without_stow() {
 	local home_dir
 	home_dir=$(mktemp -d)
@@ -210,6 +260,8 @@ main() {
 	test_clean_zsh_preserves_unmanaged_files_without_stow
 	test_clean_ghostty_preserves_unmanaged_custom_conf_without_stow
 	test_sync_tmux_rejects_legacy_config
+	test_sync_tmux_warns_when_tpm_is_missing
+	test_install_tmux_plugins_bootstraps_tpm
 	test_clean_tmux_preserves_unmanaged_config_without_stow
 	test_clean_tmux_removes_relative_stow_link_without_stow
 	test_clean_tmux_removes_folded_config_link_without_stow

--- a/test_makefile_safety.sh
+++ b/test_makefile_safety.sh
@@ -164,56 +164,6 @@ test_sync_tmux_rejects_legacy_config() {
 	assert_contains "$home_dir/.tmux.conf" 'keep me'
 }
 
-test_sync_tmux_warns_when_tpm_is_missing() {
-	local home_dir xdg_data_home
-	home_dir=$(mktemp -d)
-	xdg_data_home="$home_dir/xdg-data"
-	trap '[ -n "${home_dir-}" ] && rm -rf "$home_dir"' RETURN
-
-	HOME="$home_dir" XDG_DATA_HOME="$xdg_data_home" make sync-tmux >"$TEST_OUTPUT" 2>&1
-
-	assert_contains "$TEST_OUTPUT" 'TPM is not installed'
-	assert_contains "$TEST_OUTPUT" "$xdg_data_home/tmux/plugins/tpm"
-	assert_contains "$TEST_OUTPUT" 'make install-tmux-plugins'
-	assert_file_exists "$home_dir/.config/tmux/tmux.conf"
-}
-
-test_install_tmux_plugins_bootstraps_tpm() {
-	local home_dir xdg_data_home fake_tpm_repo plugin_dir
-	home_dir=$(mktemp -d)
-	xdg_data_home="$home_dir/xdg-data"
-	fake_tpm_repo=$(mktemp -d)
-	plugin_dir="$xdg_data_home/tmux/plugins"
-	trap '[ -n "${home_dir-}" ] && rm -rf "$home_dir"; [ -n "${fake_tpm_repo-}" ] && rm -rf "$fake_tpm_repo"' RETURN
-
-	mkdir -p "$fake_tpm_repo/bin"
-	cat >"$fake_tpm_repo/tpm" <<'EOF'
-#!/bin/bash
-exit 0
-EOF
-	cat >"$fake_tpm_repo/bin/install_plugins" <<'EOF'
-#!/bin/bash
-set -euo pipefail
-config="${XDG_CONFIG_HOME:-$HOME/.config}/tmux/tmux.conf"
-plugin_dir="${XDG_DATA_HOME:-$HOME/.local/share}/tmux/plugins/tmux-open"
-test -f "$config"
-mkdir -p "$plugin_dir"
-printf 'installed\n' >"$plugin_dir/.installed-by-test"
-EOF
-	chmod +x "$fake_tpm_repo/tpm" "$fake_tpm_repo/bin/install_plugins"
-	git -C "$fake_tpm_repo" init -q
-	git -C "$fake_tpm_repo" add tpm bin/install_plugins
-	git -C "$fake_tpm_repo" -c user.name='Dotfiles Test' -c user.email='test@example.com' commit -qm 'test fixture'
-
-	HOME="$home_dir" XDG_DATA_HOME="$xdg_data_home" make sync-tmux >"$TEST_OUTPUT" 2>&1
-	HOME="$home_dir" XDG_DATA_HOME="$xdg_data_home" make \
-		TPM_REPOSITORY="$fake_tpm_repo" install-tmux-plugins >"$TEST_OUTPUT" 2>&1
-
-	assert_file_exists "$plugin_dir/tpm/tpm"
-	assert_file_exists "$plugin_dir/tmux-open/.installed-by-test"
-	assert_contains "$TEST_OUTPUT" 'tmux plugins installed'
-}
-
 test_clean_tmux_preserves_unmanaged_config_without_stow() {
 	local home_dir
 	home_dir=$(mktemp -d)
@@ -260,8 +210,6 @@ main() {
 	test_clean_zsh_preserves_unmanaged_files_without_stow
 	test_clean_ghostty_preserves_unmanaged_custom_conf_without_stow
 	test_sync_tmux_rejects_legacy_config
-	test_sync_tmux_warns_when_tpm_is_missing
-	test_install_tmux_plugins_bootstraps_tpm
 	test_clean_tmux_preserves_unmanaged_config_without_stow
 	test_clean_tmux_removes_relative_stow_link_without_stow
 	test_clean_tmux_removes_folded_config_link_without_stow

--- a/test_makefile_safety.sh
+++ b/test_makefile_safety.sh
@@ -130,6 +130,31 @@ test_clean_ghostty_preserves_unmanaged_custom_conf_without_stow() {
 	assert_contains "$home_dir/.config/ghostty/custom.conf" 'keep me'
 }
 
+test_sync_tmux_rejects_legacy_config() {
+	local home_dir
+	home_dir=$(mktemp -d)
+	trap '[ -n "${home_dir-}" ] && rm -rf "$home_dir"' RETURN
+
+	printf 'keep me\n' >"$home_dir/.tmux.conf"
+
+	assert_make_fails "$home_dir" sync-tmux
+	assert_file_exists "$home_dir/.tmux.conf"
+	assert_contains "$home_dir/.tmux.conf" 'keep me'
+}
+
+test_clean_tmux_preserves_unmanaged_config_without_stow() {
+	local home_dir
+	home_dir=$(mktemp -d)
+	trap '[ -n "${home_dir-}" ] && rm -rf "$home_dir"' RETURN
+
+	mkdir -p "$home_dir/.config/tmux"
+	printf 'keep me\n' >"$home_dir/.config/tmux/tmux.conf"
+
+	PATH="/usr/bin:/bin" HOME="$home_dir" make clean-tmux >"$TEST_OUTPUT" 2>&1
+	assert_file_exists "$home_dir/.config/tmux/tmux.conf"
+	assert_contains "$home_dir/.config/tmux/tmux.conf" 'keep me'
+}
+
 main() {
 	cd "$REPO_ROOT"
 	test_sync_ghostty_linux_preserves_existing_custom_conf
@@ -137,6 +162,8 @@ main() {
 	test_clean_neovim_preserves_unmanaged_directory_without_stow
 	test_clean_zsh_preserves_unmanaged_files_without_stow
 	test_clean_ghostty_preserves_unmanaged_custom_conf_without_stow
+	test_sync_tmux_rejects_legacy_config
+	test_clean_tmux_preserves_unmanaged_config_without_stow
 }
 
 main "$@"

--- a/test_sync_smoke.sh
+++ b/test_sync_smoke.sh
@@ -26,6 +26,16 @@ assert_symlink_resolves_to() {
 	fi
 }
 
+assert_file_contains() {
+	local path="$1"
+	local needle="$2"
+
+	if ! grep -Fq -- "$needle" "$path"; then
+		printf 'Expected %s to contain: %s\n' "$path" "$needle" >&2
+		exit 1
+	fi
+}
+
 assert_file_not_contains() {
 	local path="$1"
 	local needle="$2"
@@ -54,6 +64,11 @@ main() {
 
 	HOME="$home_dir" make sync-tig
 	assert_symlink_resolves_to "$home_dir/.tigrc" "$REPO_ROOT/tig/.tigrc"
+
+	HOME="$home_dir" make sync-tmux
+	assert_symlink_resolves_to "$home_dir/.config/tmux" "$REPO_ROOT/tmux/.config/tmux"
+	assert_file_contains "$home_dir/.config/tmux/tmux.conf" 'set -g prefix C-a'
+	assert_file_not_contains "$home_dir/.config/tmux/tmux.conf" 'set -g prefix C-f'
 }
 
 main "$@"

--- a/test_sync_smoke.sh
+++ b/test_sync_smoke.sh
@@ -67,8 +67,8 @@ main() {
 
 	HOME="$home_dir" make sync-tmux
 	assert_symlink_resolves_to "$home_dir/.config/tmux" "$REPO_ROOT/tmux/.config/tmux"
-	assert_file_contains "$home_dir/.config/tmux/tmux.conf" 'set -g prefix C-a'
-	assert_file_not_contains "$home_dir/.config/tmux/tmux.conf" 'set -g prefix C-f'
+	assert_file_contains "$home_dir/.config/tmux/tmux.conf" 'set -g prefix C-Space'
+	assert_file_not_contains "$home_dir/.config/tmux/tmux.conf" 'set -g prefix C-a'
 }
 
 main "$@"

--- a/test_sync_smoke.sh
+++ b/test_sync_smoke.sh
@@ -54,6 +54,8 @@ main() {
 	cd "$REPO_ROOT"
 
 	assert_file_not_contains "$REPO_ROOT/README.md" 'Neovim 0.8+'
+	assert_file_contains "$REPO_ROOT/.github/workflows/ci.yml" 'sudo apt-get install -y stow tmux'
+	assert_file_contains "$REPO_ROOT/.github/workflows/ci.yml" 'make test-tmux-config'
 
 	HOME="$home_dir" make sync-neovim
 	assert_exists "$home_dir/.config/nvim/init.lua"

--- a/test_tmux_config.sh
+++ b/test_tmux_config.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+
+set -euo pipefail
+
+REPO_ROOT=$(pwd)
+CONFIG="$REPO_ROOT/tmux/.config/tmux/tmux.conf"
+SOCKET="dotfiles-tmux-test-$$"
+
+cleanup() {
+	env -u TMUX tmux -L "$SOCKET" kill-server 2>/dev/null || true
+}
+
+trap cleanup EXIT
+
+assert_equal() {
+	local expected="$1"
+	local actual="$2"
+	local description="$3"
+
+	if [ "$actual" != "$expected" ]; then
+		printf 'Expected %s to be %q, got %q\n' "$description" "$expected" "$actual" >&2
+		exit 1
+	fi
+}
+
+assert_contains() {
+	local value="$1"
+	local expected="$2"
+	local description="$3"
+
+	if [[ "$value" != *"$expected"* ]]; then
+		printf 'Expected %s to contain %q, got %q\n' "$description" "$expected" "$value" >&2
+		exit 1
+	fi
+}
+
+assert_not_contains() {
+	local value="$1"
+	local unexpected="$2"
+	local description="$3"
+
+	if [[ "$value" == *"$unexpected"* ]]; then
+		printf 'Expected %s to omit %q, got %q\n' "$description" "$unexpected" "$value" >&2
+		exit 1
+	fi
+}
+
+tmux_test() {
+	env -u TMUX tmux -L "$SOCKET" "$@"
+}
+
+main() {
+	cd "$REPO_ROOT"
+
+	tmux_test -f /dev/null new-session -d
+	tmux_test source-file "$CONFIG"
+
+	assert_equal 'C-Space' "$(tmux_test show-options -gv prefix)" 'tmux prefix'
+	assert_equal 'tmux-256color' "$(tmux_test show-options -gv default-terminal)" 'default terminal'
+	assert_equal 'external' "$(tmux_test show-options -gv set-clipboard)" 'clipboard integration'
+
+	local terminal_overrides
+	terminal_overrides=$(tmux_test show-options -gqv terminal-overrides)
+	assert_not_contains "$terminal_overrides" 'smcup@' 'terminal overrides'
+	assert_not_contains "$terminal_overrides" 'rmcup@' 'terminal overrides'
+	assert_not_contains "$terminal_overrides" ':Tc' 'terminal overrides'
+
+	assert_equal "$HOME/.local/share/tmux/plugins/" \
+		"$(tmux_test show-environment -g TMUX_PLUGIN_MANAGER_PATH | cut -d= -f2-)" \
+		'TPM plugin path'
+
+	local status_left
+	status_left=$(tmux_test show-options -gv status-left)
+	assert_not_contains "$status_left" '#{prefix_highlight}' 'status-left'
+	assert_contains "$status_left" 'client_prefix' 'status-left'
+
+	local copy_bindings
+	copy_bindings=$(tmux_test list-keys -T copy-mode-vi)
+	assert_contains "$copy_bindings" 'copy-pipe-and-cancel' 'copy-mode bindings'
+
+	local sync_binding
+	sync_binding=$(tmux_test list-keys -T prefix | grep -E '[[:space:]]C-s[[:space:]]')
+	assert_contains "$sync_binding" 'fg=colour148' 'synchronize-panes binding'
+	assert_not_contains "$sync_binding" 'pane-border-format' 'synchronize-panes binding'
+
+	if tmux_test list-keys -T edit-mode-vi >/dev/null 2>&1; then
+		printf 'Expected edit-mode-vi table to be absent\n' >&2
+		exit 1
+	fi
+}
+
+main "$@"

--- a/test_tmux_config.sh
+++ b/test_tmux_config.sh
@@ -8,10 +8,14 @@ SOCKET="dotfiles-tmux-test-$$"
 SUBAGENT_SOCKET="/tmp/dotfiles-test-$$-tmux-subagents.sock"
 TEST_HOME=$(mktemp -d)
 TEST_XDG_DATA_HOME="$TEST_HOME/xdg-data"
+CONTROL_CLIENT_PID=''
 
 cleanup() {
 	HOME="$TEST_HOME" XDG_DATA_HOME="$TEST_XDG_DATA_HOME" env -u TMUX tmux -L "$SOCKET" kill-server 2>/dev/null || true
 	HOME="$TEST_HOME" XDG_DATA_HOME="$TEST_XDG_DATA_HOME" env -u TMUX tmux -S "$SUBAGENT_SOCKET" kill-server 2>/dev/null || true
+	if [ -n "$CONTROL_CLIENT_PID" ]; then
+		kill "$CONTROL_CLIENT_PID" 2>/dev/null || true
+	fi
 	rm -rf "$TEST_HOME"
 	rm -f "$SUBAGENT_SOCKET"
 }
@@ -59,6 +63,29 @@ subagent_tmux_test() {
 	HOME="$TEST_HOME" XDG_DATA_HOME="$TEST_XDG_DATA_HOME" env -u TMUX tmux -S "$SUBAGENT_SOCKET" "$@"
 }
 
+assert_session_created_via_binding() {
+	local client="$1"
+	local session_name="$2"
+	local sessions
+	local attempt
+
+	tmux_test send-keys -K -t "$client" C-Space
+	tmux_test send-keys -K -t "$client" N
+	tmux_test send-keys -Kl -t "$client" "$session_name"
+	tmux_test send-keys -K -t "$client" Enter
+
+	for ((attempt = 0; attempt < 50; attempt++)); do
+		sessions=$(tmux_test list-sessions -F '#{session_name}')
+		if grep -Fxq -- "$session_name" <<<"$sessions"; then
+			return 0
+		fi
+		sleep 0.02
+	done
+
+	printf 'Expected session binding to preserve name %q, got:\n%s\n' "$session_name" "$sessions" >&2
+	return 1
+}
+
 main() {
 	cd "$REPO_ROOT"
 
@@ -66,6 +93,7 @@ main() {
 	tmux_test source-file "$CONFIG"
 
 	assert_equal 'C-Space' "$(tmux_test show-options -gv prefix)" 'tmux prefix'
+	assert_contains "$(<"$CONFIG")" 'set -g default-terminal "tmux-256color"' 'tmux config'
 	assert_equal 'tmux-256color' "$(tmux_test show-options -gv default-terminal)" 'default terminal'
 	assert_equal 'external' "$(tmux_test show-options -gv set-clipboard)" 'clipboard integration'
 	assert_equal '10' "$(tmux_test show-options -sv escape-time)" 'escape time'
@@ -108,6 +136,27 @@ main() {
 	assert_contains "$new_session_binding" 'command-prompt' 'new-session binding'
 	assert_contains "$new_session_binding" 'new-session -s' 'new-session binding'
 	assert_contains "$new_session_binding" "%%%" 'quote-safe new-session binding'
+
+	local control_input="$TEST_HOME/control-input"
+	local control_output="$TEST_HOME/control-output"
+	local control_client=''
+	local attempt
+	mkfifo "$control_input"
+	exec 9<>"$control_input"
+	tmux_test -C attach-session <&9 >"$control_output" 2>&1 &
+	CONTROL_CLIENT_PID=$!
+	for ((attempt = 0; attempt < 50; attempt++)); do
+		control_client=$(tmux_test list-clients -F '#{client_name}' 2>/dev/null | head -1 || true)
+		[ -n "$control_client" ] && break
+		sleep 0.02
+	done
+	if [ -z "$control_client" ]; then
+		printf 'Expected tmux control client to attach\n' >&2
+		exit 1
+	fi
+	assert_session_created_via_binding "$control_client" "session with spaces"
+	assert_session_created_via_binding "$control_client" "session'quote"
+	assert_session_created_via_binding "$control_client" 'session"quote'
 
 	local choose_session_binding
 	choose_session_binding=$(grep -E '[[:space:]]S[[:space:]]' <<<"$prefix_bindings" || true)

--- a/test_tmux_config.sh
+++ b/test_tmux_config.sh
@@ -5,9 +5,12 @@ set -euo pipefail
 REPO_ROOT=$(pwd)
 CONFIG="$REPO_ROOT/tmux/.config/tmux/tmux.conf"
 SOCKET="dotfiles-tmux-test-$$"
+SUBAGENT_SOCKET="/tmp/dotfiles-test-$$-tmux-subagents.sock"
 
 cleanup() {
 	env -u TMUX tmux -L "$SOCKET" kill-server 2>/dev/null || true
+	env -u TMUX tmux -S "$SUBAGENT_SOCKET" kill-server 2>/dev/null || true
+	rm -f "$SUBAGENT_SOCKET"
 }
 
 trap cleanup EXIT
@@ -47,6 +50,10 @@ assert_not_contains() {
 
 tmux_test() {
 	env -u TMUX tmux -L "$SOCKET" "$@"
+}
+
+subagent_tmux_test() {
+	env -u TMUX tmux -S "$SUBAGENT_SOCKET" "$@"
 }
 
 main() {
@@ -107,6 +114,22 @@ main() {
 
 	if tmux_test list-keys -T edit-mode-vi >/dev/null 2>&1; then
 		printf 'Expected edit-mode-vi table to be absent\n' >&2
+		exit 1
+	fi
+
+	subagent_tmux_test -f /dev/null new-session -d
+	subagent_tmux_test source-file "$CONFIG"
+
+	assert_equal 'C-b' "$(subagent_tmux_test show-options -gv prefix)" 'subagent tmux prefix'
+	assert_equal '0' "$(subagent_tmux_test show-options -gv base-index)" 'subagent window base index'
+	assert_equal '0' "$(subagent_tmux_test show-options -wgv pane-base-index)" 'subagent pane base index'
+	assert_equal 'off' "$(subagent_tmux_test show-options -gv status)" 'subagent status bar'
+	assert_equal '0.0' \
+		"$(subagent_tmux_test list-panes -F '#{window_index}.#{pane_index}')" \
+		'subagent initial target'
+
+	if subagent_tmux_test show-environment -g TMUX_PLUGIN_MANAGER_PATH >/dev/null 2>&1; then
+		printf 'Expected subagent tmux to skip TPM configuration\n' >&2
 		exit 1
 	fi
 }

--- a/test_tmux_config.sh
+++ b/test_tmux_config.sh
@@ -79,9 +79,9 @@ main() {
 	assert_not_contains "$terminal_overrides" 'rmcup@' 'terminal overrides'
 	assert_not_contains "$terminal_overrides" ':Tc' 'terminal overrides'
 
-	assert_equal "$TEST_XDG_DATA_HOME/tmux/plugins/" \
-		"$(tmux_test show-environment -g TMUX_PLUGIN_MANAGER_PATH | cut -d= -f2-)" \
-		'TPM plugin path'
+	assert_not_contains "$(<"$CONFIG")" 'TMUX_PLUGIN_MANAGER_PATH' 'tmux config'
+	assert_not_contains "$(<"$CONFIG")" 'tmux-plugins/' 'tmux config'
+	assert_not_contains "$(<"$CONFIG")" 'tmux-open' 'tmux config'
 
 	local status_left
 	status_left=$(tmux_test show-options -gv status-left)
@@ -94,12 +94,9 @@ main() {
 	assert_contains "$copy_bindings" 'copy-selection-and-cancel' 'copy-mode bindings'
 	assert_not_contains "$copy_bindings" 'pbcopy' 'copy-mode bindings'
 
-	assert_not_contains "$(<"$CONFIG")" 'tmux-plugins/tmux-yank' 'tmux plugins'
-	assert_not_contains "$(<"$CONFIG")" 'tmux-plugins/tmux-sensible' 'tmux plugins'
-	assert_not_contains "$(<"$CONFIG")" 'tmux-plugins/tmux-prefix-highlight' 'tmux plugins'
-
 	local prefix_bindings
 	prefix_bindings=$(tmux_test list-keys -T prefix)
+	assert_not_contains "$prefix_bindings" '/tpm/' 'prefix bindings'
 
 	local sync_binding
 	sync_binding=$(grep -E '[[:space:]]C-s[[:space:]]' <<<"$prefix_bindings")
@@ -131,10 +128,6 @@ main() {
 		"$(subagent_tmux_test list-panes -F '#{window_index}.#{pane_index}')" \
 		'subagent initial target'
 
-	if subagent_tmux_test show-environment -g TMUX_PLUGIN_MANAGER_PATH >/dev/null 2>&1; then
-		printf 'Expected subagent tmux to skip TPM configuration\n' >&2
-		exit 1
-	fi
 }
 
 main "$@"

--- a/test_tmux_config.sh
+++ b/test_tmux_config.sh
@@ -6,10 +6,13 @@ REPO_ROOT=$(pwd)
 CONFIG="$REPO_ROOT/tmux/.config/tmux/tmux.conf"
 SOCKET="dotfiles-tmux-test-$$"
 SUBAGENT_SOCKET="/tmp/dotfiles-test-$$-tmux-subagents.sock"
+TEST_HOME=$(mktemp -d)
+TEST_XDG_DATA_HOME="$TEST_HOME/xdg-data"
 
 cleanup() {
-	env -u TMUX tmux -L "$SOCKET" kill-server 2>/dev/null || true
-	env -u TMUX tmux -S "$SUBAGENT_SOCKET" kill-server 2>/dev/null || true
+	HOME="$TEST_HOME" XDG_DATA_HOME="$TEST_XDG_DATA_HOME" env -u TMUX tmux -L "$SOCKET" kill-server 2>/dev/null || true
+	HOME="$TEST_HOME" XDG_DATA_HOME="$TEST_XDG_DATA_HOME" env -u TMUX tmux -S "$SUBAGENT_SOCKET" kill-server 2>/dev/null || true
+	rm -rf "$TEST_HOME"
 	rm -f "$SUBAGENT_SOCKET"
 }
 
@@ -49,17 +52,17 @@ assert_not_contains() {
 }
 
 tmux_test() {
-	env -u TMUX tmux -L "$SOCKET" "$@"
+	HOME="$TEST_HOME" XDG_DATA_HOME="$TEST_XDG_DATA_HOME" env -u TMUX tmux -L "$SOCKET" "$@"
 }
 
 subagent_tmux_test() {
-	env -u TMUX tmux -S "$SUBAGENT_SOCKET" "$@"
+	HOME="$TEST_HOME" XDG_DATA_HOME="$TEST_XDG_DATA_HOME" env -u TMUX tmux -S "$SUBAGENT_SOCKET" "$@"
 }
 
 main() {
 	cd "$REPO_ROOT"
 
-	tmux_test -f /dev/null new-session -d
+	tmux_test -f "$CONFIG" new-session -d
 	tmux_test source-file "$CONFIG"
 
 	assert_equal 'C-Space' "$(tmux_test show-options -gv prefix)" 'tmux prefix'
@@ -76,7 +79,7 @@ main() {
 	assert_not_contains "$terminal_overrides" 'rmcup@' 'terminal overrides'
 	assert_not_contains "$terminal_overrides" ':Tc' 'terminal overrides'
 
-	assert_equal "$HOME/.local/share/tmux/plugins/" \
+	assert_equal "$TEST_XDG_DATA_HOME/tmux/plugins/" \
 		"$(tmux_test show-environment -g TMUX_PLUGIN_MANAGER_PATH | cut -d= -f2-)" \
 		'TPM plugin path'
 
@@ -107,6 +110,7 @@ main() {
 	new_session_binding=$(grep -E '[[:space:]]N[[:space:]]' <<<"$prefix_bindings" || true)
 	assert_contains "$new_session_binding" 'command-prompt' 'new-session binding'
 	assert_contains "$new_session_binding" 'new-session -s' 'new-session binding'
+	assert_contains "$new_session_binding" "%%%" 'quote-safe new-session binding'
 
 	local choose_session_binding
 	choose_session_binding=$(grep -E '[[:space:]]S[[:space:]]' <<<"$prefix_bindings" || true)
@@ -117,8 +121,7 @@ main() {
 		exit 1
 	fi
 
-	subagent_tmux_test -f /dev/null new-session -d
-	subagent_tmux_test source-file "$CONFIG"
+	subagent_tmux_test -f "$CONFIG" new-session -d
 
 	assert_equal 'C-b' "$(subagent_tmux_test show-options -gv prefix)" 'subagent tmux prefix'
 	assert_equal '0' "$(subagent_tmux_test show-options -gv base-index)" 'subagent window base index'

--- a/test_tmux_config.sh
+++ b/test_tmux_config.sh
@@ -58,6 +58,10 @@ main() {
 	assert_equal 'C-Space' "$(tmux_test show-options -gv prefix)" 'tmux prefix'
 	assert_equal 'tmux-256color' "$(tmux_test show-options -gv default-terminal)" 'default terminal'
 	assert_equal 'external' "$(tmux_test show-options -gv set-clipboard)" 'clipboard integration'
+	assert_equal '10' "$(tmux_test show-options -sv escape-time)" 'escape time'
+	assert_equal '100000' "$(tmux_test show-options -gv history-limit)" 'history limit'
+	assert_equal 'off' "$(tmux_test show-options -wgv aggressive-resize)" 'aggressive resize'
+	assert_equal 'off' "$(tmux_test show-options -gv set-titles)" 'terminal title updates'
 
 	local terminal_overrides
 	terminal_overrides=$(tmux_test show-options -gqv terminal-overrides)
@@ -76,7 +80,13 @@ main() {
 
 	local copy_bindings
 	copy_bindings=$(tmux_test list-keys -T copy-mode-vi)
-	assert_contains "$copy_bindings" 'copy-pipe-and-cancel' 'copy-mode bindings'
+	assert_contains "$copy_bindings" 'y' 'copy-mode bindings'
+	assert_contains "$copy_bindings" 'copy-selection-and-cancel' 'copy-mode bindings'
+	assert_not_contains "$copy_bindings" 'pbcopy' 'copy-mode bindings'
+
+	assert_not_contains "$(<"$CONFIG")" 'tmux-plugins/tmux-yank' 'tmux plugins'
+	assert_not_contains "$(<"$CONFIG")" 'tmux-plugins/tmux-sensible' 'tmux plugins'
+	assert_not_contains "$(<"$CONFIG")" 'tmux-plugins/tmux-prefix-highlight' 'tmux plugins'
 
 	local sync_binding
 	sync_binding=$(tmux_test list-keys -T prefix | grep -E '[[:space:]]C-s[[:space:]]')

--- a/test_tmux_config.sh
+++ b/test_tmux_config.sh
@@ -88,10 +88,22 @@ main() {
 	assert_not_contains "$(<"$CONFIG")" 'tmux-plugins/tmux-sensible' 'tmux plugins'
 	assert_not_contains "$(<"$CONFIG")" 'tmux-plugins/tmux-prefix-highlight' 'tmux plugins'
 
+	local prefix_bindings
+	prefix_bindings=$(tmux_test list-keys -T prefix)
+
 	local sync_binding
-	sync_binding=$(tmux_test list-keys -T prefix | grep -E '[[:space:]]C-s[[:space:]]')
+	sync_binding=$(grep -E '[[:space:]]C-s[[:space:]]' <<<"$prefix_bindings")
 	assert_contains "$sync_binding" 'fg=colour148' 'synchronize-panes binding'
 	assert_not_contains "$sync_binding" 'pane-border-format' 'synchronize-panes binding'
+
+	local new_session_binding
+	new_session_binding=$(grep -E '[[:space:]]N[[:space:]]' <<<"$prefix_bindings" || true)
+	assert_contains "$new_session_binding" 'command-prompt' 'new-session binding'
+	assert_contains "$new_session_binding" 'new-session -s' 'new-session binding'
+
+	local choose_session_binding
+	choose_session_binding=$(grep -E '[[:space:]]S[[:space:]]' <<<"$prefix_bindings" || true)
+	assert_contains "$choose_session_binding" 'choose-tree -Zs' 'session picker binding'
 
 	if tmux_test list-keys -T edit-mode-vi >/dev/null 2>&1; then
 		printf 'Expected edit-mode-vi table to be absent\n' >&2

--- a/tmux/.config/tmux/tmux.conf
+++ b/tmux/.config/tmux/tmux.conf
@@ -1,6 +1,13 @@
 # INSTALL
 # Run `make sync-tmux` from the dotfiles repository.
 #
+# Pi subagents use a dedicated tmux server and require the default 0-based indexes.
+%if "#{m:*tmux-subagents.sock,#{socket_path}}"
+set -g base-index 0
+setw -g pane-base-index 0
+set -g status off
+%else
+
 # Set prefix key to Ctrl-Space instead of default Ctrl-b
 unbind C-b
 set -g prefix C-Space
@@ -93,5 +100,7 @@ setw -g window-status-current-format "#[fg=colour236,bg=colour240,nobold,nounder
 set-environment -g TMUX_PLUGIN_MANAGER_PATH "$HOME/.local/share/tmux/plugins/"
 set -g @plugin 'tmux-plugins/tpm'
 set -g @plugin 'tmux-plugins/tmux-open'
-# Initialize TMUX plugin manager (keep this line at the very bottom of tmux.conf)
+# Initialize TPM after all plugin declarations.
 run '~/.local/share/tmux/plugins/tpm/tpm'
+
+%endif

--- a/tmux/.config/tmux/tmux.conf
+++ b/tmux/.config/tmux/tmux.conf
@@ -1,12 +1,11 @@
 # INSTALL
 # Run `make sync-tmux` from the dotfiles repository.
 #
-# Set prefix key to C-a instead of default C-b
+# Set prefix key to Ctrl-Space instead of default Ctrl-b
 unbind C-b
-set -g prefix C-a
-bind C-a send-prefix
-# Toggle the last window by hitting C-a again
-# bind-key C-a last-window
+set -g prefix C-Space
+bind C-Space send-prefix
+# Press the prefix twice to send Ctrl-Space to the active pane.
 # if multiple clients are attached to the same window, maximize it to the
 # bigger one
 set-window-option -g aggressive-resize
@@ -30,7 +29,7 @@ set -g default-terminal "screen-256color"
 bind-key v split-window -h -c '#{pane_current_path}'
 bind-key s split-window -v -c '#{pane_current_path}'
 # Pressing Ctrl+Shift+Left (will move the current window to the left. Similarly
-# right. No need to use the prefix (C-a).
+# right. No need to use the prefix.
 bind-key -n C-S-Left swap-window -t -1
 bind-key -n C-S-Right swap-window -t +1
 # Source file

--- a/tmux/.config/tmux/tmux.conf
+++ b/tmux/.config/tmux/tmux.conf
@@ -28,6 +28,9 @@ bind-key -n C-S-Left swap-window -t -1
 bind-key -n C-S-Right swap-window -t +1
 # Source file
 bind r source-file ~/.config/tmux/tmux.conf \; display "Reloaded!"
+# Create and switch between named sessions.
+bind-key N command-prompt -p "New session:" "new-session -s '%%'"
+bind-key S choose-tree -Zs
 # Use Vim keybindings in copy mode. Native OSC 52 support copies to Ghostty.
 setw -g mode-keys vi
 unbind -T copy-mode-vi Enter

--- a/tmux/.config/tmux/tmux.conf
+++ b/tmux/.config/tmux/tmux.conf
@@ -6,9 +6,6 @@ unbind C-b
 set -g prefix C-Space
 bind C-Space send-prefix
 # Press the prefix twice to send Ctrl-Space to the active pane.
-# if multiple clients are attached to the same window, maximize it to the
-# bigger one
-set-window-option -g aggressive-resize
 # Start windows and pane numbering with index 1 instead of 0
 set -g base-index 1
 setw -g pane-base-index 1
@@ -31,11 +28,12 @@ bind-key -n C-S-Left swap-window -t -1
 bind-key -n C-S-Right swap-window -t +1
 # Source file
 bind r source-file ~/.config/tmux/tmux.conf \; display "Reloaded!"
-# Use Vim keybindings in copy mode. tmux-yank owns the copy bindings.
+# Use Vim keybindings in copy mode. Native OSC 52 support copies to Ghostty.
 setw -g mode-keys vi
 unbind -T copy-mode-vi Enter
 unbind -T copy-mode-vi Space
 bind-key -T copy-mode-vi v send-keys -X begin-selection
+bind-key -T copy-mode-vi y send-keys -X copy-selection-and-cancel
 # emacs key bindings in tmux command prompt (prefix + :) are better than
 # vi keys, even for vim users
 set -g status-keys emacs
@@ -48,15 +46,11 @@ bind C-s if -F '#{pane_synchronized}' \
                       setw pane-active-border-style fg=colour148,bg=default' \
                    'setw synchronize-panes on; \
                     setw pane-active-border-style fg=red,bg=default'
-# Faster command sequence
-set -s escape-time 0
-# Have a very large history
-set -g history-limit 1000000
+# Keep key sequences reliable while avoiding a noticeable Escape delay.
+set -s escape-time 10
+set -g history-limit 100000
 # Mouse mode on
 set -g mouse on
-# Set title
-set -g set-titles on
-set -g set-titles-string "#T"
 # Equally resize all panes
 bind-key = select-layout even-horizontal
 bind-key | select-layout even-vertical
@@ -75,16 +69,12 @@ bind-key l select-pane -R
 bind-key x kill-pane
 # This tmux statusbar config was created by tmuxline.vim
 # on Wed, 25 Nov 2015
-set -g status "on"
 set -g status-bg "colour236"
-set -g status-justify "left"
 set -g status-position "top"
 set -g status-left-length "100"
-set -g status-left-style "none"
 set -g status-right-length "100"
-set -g status-right-style "none"
 set -g status-style "none"
-set -g status-left "#{prefix_highlight}#[fg=colour22,bg=colour148,bold] #S #[fg=colour148,bg=colour236,nobold,nounderscore,noitalics]"
+set -g status-left "#{?client_prefix,#[fg=colour231,bg=colour04] ^SPACE #[default],}#[fg=colour22,bg=colour148,bold] #S #[fg=colour148,bg=colour236,nobold,nounderscore,noitalics]"
 set -g status-right "#[fg=colour240,bg=colour236,nobold,nounderscore,noitalics]#[fg=colour250,bg=colour240] %Y-%m-%d %H:%M #[fg=colour252,bg=colour240,nobold,nounderscore,noitalics]#[fg=colour241,bg=colour252] #h "
 set -g pane-active-border-style fg=colour148
 set -g pane-border-style fg=colour240
@@ -100,8 +90,5 @@ setw -g window-status-current-format "#[fg=colour236,bg=colour240,nobold,nounder
 set-environment -g TMUX_PLUGIN_MANAGER_PATH "$HOME/.local/share/tmux/plugins/"
 set -g @plugin 'tmux-plugins/tpm'
 set -g @plugin 'tmux-plugins/tmux-open'
-set -g @plugin 'tmux-plugins/tmux-yank'
-set -g @plugin 'tmux-plugins/tmux-prefix-highlight'
-set -g @plugin 'tmux-plugins/tmux-sensible'
 # Initialize TMUX plugin manager (keep this line at the very bottom of tmux.conf)
 run '~/.local/share/tmux/plugins/tpm/tpm'

--- a/tmux/.config/tmux/tmux.conf
+++ b/tmux/.config/tmux/tmux.conf
@@ -95,18 +95,5 @@ setw -g window-status-separator ""
 setw -g window-status-style bg=colour236
 setw -g window-status-format "#[fg=colour245,bg=colour236] #I #[fg=colour245,bg=colour236]#W "
 setw -g window-status-current-format "#[fg=colour236,bg=colour240,nobold,nounderscore,noitalics]#[fg=colour231,bg=colour240] #I #[fg=colour231,bg=colour240]#{?window_zoomed_flag,#[fg=green][],}#W #[fg=colour240,bg=colour236,nobold,nounderscore,noitalics]"
-# List of plugins
-# see this https://github.com/tmux-plugins/tpm to installation
-%if "#{XDG_DATA_HOME}"
-set-environment -g TMUX_PLUGIN_MANAGER_PATH "$XDG_DATA_HOME/tmux/plugins/"
-%else
-set-environment -g TMUX_PLUGIN_MANAGER_PATH "$HOME/.local/share/tmux/plugins/"
-%endif
-set -g @plugin 'tmux-plugins/tpm'
-set -g @plugin 'tmux-plugins/tmux-open'
-# Initialize TPM after all plugin declarations when it is installed.
-if-shell 'test -x "#{TMUX_PLUGIN_MANAGER_PATH}tpm/tpm"' {
-    run-shell '"#{TMUX_PLUGIN_MANAGER_PATH}tpm/tpm"'
-}
 
 %endif

--- a/tmux/.config/tmux/tmux.conf
+++ b/tmux/.config/tmux/tmux.conf
@@ -36,7 +36,7 @@ bind-key -n C-S-Right swap-window -t +1
 # Source file
 bind r source-file ~/.config/tmux/tmux.conf \; display "Reloaded!"
 # Create and switch between named sessions.
-bind-key N command-prompt -p "New session:" "new-session -s '%%'"
+bind-key N command-prompt -p "New session:" "new-session -s '%%%'"
 bind-key S choose-tree -Zs
 # Use Vim keybindings in copy mode. Native OSC 52 support copies to Ghostty.
 setw -g mode-keys vi
@@ -97,10 +97,16 @@ setw -g window-status-format "#[fg=colour245,bg=colour236] #I #[fg=colour245,bg=
 setw -g window-status-current-format "#[fg=colour236,bg=colour240,nobold,nounderscore,noitalics]#[fg=colour231,bg=colour240] #I #[fg=colour231,bg=colour240]#{?window_zoomed_flag,#[fg=green][],}#W #[fg=colour240,bg=colour236,nobold,nounderscore,noitalics]"
 # List of plugins
 # see this https://github.com/tmux-plugins/tpm to installation
+%if "#{XDG_DATA_HOME}"
+set-environment -g TMUX_PLUGIN_MANAGER_PATH "$XDG_DATA_HOME/tmux/plugins/"
+%else
 set-environment -g TMUX_PLUGIN_MANAGER_PATH "$HOME/.local/share/tmux/plugins/"
+%endif
 set -g @plugin 'tmux-plugins/tpm'
 set -g @plugin 'tmux-plugins/tmux-open'
-# Initialize TPM after all plugin declarations.
-run '~/.local/share/tmux/plugins/tpm/tpm'
+# Initialize TPM after all plugin declarations when it is installed.
+if-shell 'test -x "#{TMUX_PLUGIN_MANAGER_PATH}tpm/tpm"' {
+    run-shell '"#{TMUX_PLUGIN_MANAGER_PATH}tpm/tpm"'
+}
 
 %endif

--- a/tmux/.config/tmux/tmux.conf
+++ b/tmux/.config/tmux/tmux.conf
@@ -21,9 +21,6 @@ setw -ag word-separators "'"
 set -g display-panes-time 2000
 # tmux messages are displayed for 4 seconds
 set -g display-time 4000
-# {n}vim compability
-set-option -ga terminal-overrides ",xterm-256color:Tc"
-set -g default-terminal "screen-256color"
 # Split horiziontal and vertical splits, instead of % and "
 # Also open them in the same directory
 bind-key v split-window -h -c '#{pane_current_path}'
@@ -33,23 +30,12 @@ bind-key s split-window -v -c '#{pane_current_path}'
 bind-key -n C-S-Left swap-window -t -1
 bind-key -n C-S-Right swap-window -t +1
 # Source file
-unbind r
 bind r source-file ~/.config/tmux/tmux.conf \; display "Reloaded!"
-# Use vim keybindings in copy mode
+# Use Vim keybindings in copy mode. tmux-yank owns the copy bindings.
 setw -g mode-keys vi
-# Update default binding of `Enter` and `Space to also use copy-pipe
 unbind -T copy-mode-vi Enter
 unbind -T copy-mode-vi Space
-bind-key -T edit-mode-vi Up send-keys -X history-up
-bind-key -T edit-mode-vi Down send-keys -X history-down
-# setup 'v' to begin selection as in Vim
-bind-key -T copy-mode-vi 'v' send-keys -X begin-selection
-# copy text with `y` in copy mode
-# bind-key -T copy-mode-vi 'y' send -X copy-selection-and-cancel\; run "tmux save -|pbcopy >/dev/null 2>&1"
-bind-key -T copy-mode-vi 'y' send -X copy-selection-and-cancel
-# copy text with mouse selection without pressing any key
-bind-key -T copy-mode-vi MouseDragEnd1Pane send -X copy-selection-and-cancel\; run "tmux save -|pbcopy >/dev/null 2>&1"
-# bind-key -T copy-mode-vi MouseDragEnd1Pane send -X copy-selection-and-cancel
+bind-key -T copy-mode-vi v send-keys -X begin-selection
 # emacs key bindings in tmux command prompt (prefix + :) are better than
 # vi keys, even for vim users
 set -g status-keys emacs
@@ -59,20 +45,15 @@ set -g focus-events on
 # borders become red as an indication.
 bind C-s if -F '#{pane_synchronized}' \
                      'setw synchronize-panes off; \
-                      setw pane-active-border-style fg=colour63,bg=default; \
-                      setw pane-border-format       " #P "' \
+                      setw pane-active-border-style fg=colour148,bg=default' \
                    'setw synchronize-panes on; \
-                    setw pane-active-border-style fg=red; \
-                    setw pane-border-format       " #P - Pane Synchronization ON "'
+                    setw pane-active-border-style fg=red,bg=default'
 # Faster command sequence
 set -s escape-time 0
 # Have a very large history
 set -g history-limit 1000000
 # Mouse mode on
-set -g terminal-overrides 'xterm*:smcup@:rmcup@'
 set -g mouse on
-# alacritty bug for clipboard
-set -g set-clipboard off
 # Set title
 set -g set-titles on
 set -g set-titles-string "#T"
@@ -109,7 +90,6 @@ set -g pane-active-border-style fg=colour148
 set -g pane-border-style fg=colour240
 set -g message-style fg=colour231,bg=colour240
 set -g message-command-style fg=colour231,bg=colour240
-setw -g window-status-style fg=colour245,none
 setw -g window-status-activity-style bg=colour236,fg=colour148,none
 setw -g window-status-separator ""
 setw -g window-status-style bg=colour236
@@ -117,10 +97,11 @@ setw -g window-status-format "#[fg=colour245,bg=colour236] #I #[fg=colour245,bg=
 setw -g window-status-current-format "#[fg=colour236,bg=colour240,nobold,nounderscore,noitalics]#[fg=colour231,bg=colour240] #I #[fg=colour231,bg=colour240]#{?window_zoomed_flag,#[fg=green][],}#W #[fg=colour240,bg=colour236,nobold,nounderscore,noitalics]"
 # List of plugins
 # see this https://github.com/tmux-plugins/tpm to installation
+set-environment -g TMUX_PLUGIN_MANAGER_PATH "$HOME/.local/share/tmux/plugins/"
 set -g @plugin 'tmux-plugins/tpm'
 set -g @plugin 'tmux-plugins/tmux-open'
 set -g @plugin 'tmux-plugins/tmux-yank'
 set -g @plugin 'tmux-plugins/tmux-prefix-highlight'
 set -g @plugin 'tmux-plugins/tmux-sensible'
 # Initialize TMUX plugin manager (keep this line at the very bottom of tmux.conf)
-run '~/.tmux/plugins/tpm/tpm'
+run '~/.local/share/tmux/plugins/tpm/tpm'

--- a/tmux/.config/tmux/tmux.conf
+++ b/tmux/.config/tmux/tmux.conf
@@ -13,6 +13,9 @@ unbind C-b
 set -g prefix C-Space
 bind C-Space send-prefix
 # Press the prefix twice to send Ctrl-Space to the active pane.
+# Ghostty is the outer xterm-ghostty terminal; applications inside tmux should
+# use tmux's own modern terminfo entry.
+set -g default-terminal "tmux-256color"
 # Start windows and pane numbering with index 1 instead of 0
 set -g base-index 1
 setw -g pane-base-index 1
@@ -36,7 +39,7 @@ bind-key -n C-S-Right swap-window -t +1
 # Source file
 bind r source-file ~/.config/tmux/tmux.conf \; display "Reloaded!"
 # Create and switch between named sessions.
-bind-key N command-prompt -p "New session:" "new-session -s '%%%'"
+bind-key N command-prompt -p "New session:" 'new-session -s "%%%"'
 bind-key S choose-tree -Zs
 # Use Vim keybindings in copy mode. Native OSC 52 support copies to Ghostty.
 setw -g mode-keys vi

--- a/tmux/.config/tmux/tmux.conf
+++ b/tmux/.config/tmux/tmux.conf
@@ -1,0 +1,127 @@
+# INSTALL
+# Run `make sync-tmux` from the dotfiles repository.
+#
+# Set prefix key to C-a instead of default C-b
+unbind C-b
+set -g prefix C-a
+bind C-a send-prefix
+# Toggle the last window by hitting C-a again
+# bind-key C-a last-window
+# if multiple clients are attached to the same window, maximize it to the
+# bigger one
+set-window-option -g aggressive-resize
+# Start windows and pane numbering with index 1 instead of 0
+set -g base-index 1
+setw -g pane-base-index 1
+# re-number windows when one is closed
+set -g renumber-windows on
+# word separators for automatic word selection
+setw -g word-separators ' @"=()[]_-:,.'
+setw -ag word-separators "'"
+# Show times longer than supposed
+set -g display-panes-time 2000
+# tmux messages are displayed for 4 seconds
+set -g display-time 4000
+# {n}vim compability
+set-option -ga terminal-overrides ",xterm-256color:Tc"
+set -g default-terminal "screen-256color"
+# Split horiziontal and vertical splits, instead of % and "
+# Also open them in the same directory
+bind-key v split-window -h -c '#{pane_current_path}'
+bind-key s split-window -v -c '#{pane_current_path}'
+# Pressing Ctrl+Shift+Left (will move the current window to the left. Similarly
+# right. No need to use the prefix (C-a).
+bind-key -n C-S-Left swap-window -t -1
+bind-key -n C-S-Right swap-window -t +1
+# Source file
+unbind r
+bind r source-file ~/.config/tmux/tmux.conf \; display "Reloaded!"
+# Use vim keybindings in copy mode
+setw -g mode-keys vi
+# Update default binding of `Enter` and `Space to also use copy-pipe
+unbind -T copy-mode-vi Enter
+unbind -T copy-mode-vi Space
+bind-key -T edit-mode-vi Up send-keys -X history-up
+bind-key -T edit-mode-vi Down send-keys -X history-down
+# setup 'v' to begin selection as in Vim
+bind-key -T copy-mode-vi 'v' send-keys -X begin-selection
+# copy text with `y` in copy mode
+# bind-key -T copy-mode-vi 'y' send -X copy-selection-and-cancel\; run "tmux save -|pbcopy >/dev/null 2>&1"
+bind-key -T copy-mode-vi 'y' send -X copy-selection-and-cancel
+# copy text with mouse selection without pressing any key
+bind-key -T copy-mode-vi MouseDragEnd1Pane send -X copy-selection-and-cancel\; run "tmux save -|pbcopy >/dev/null 2>&1"
+# bind-key -T copy-mode-vi MouseDragEnd1Pane send -X copy-selection-and-cancel
+# emacs key bindings in tmux command prompt (prefix + :) are better than
+# vi keys, even for vim users
+set -g status-keys emacs
+# focus events enabled for terminals that support them
+set -g focus-events on
+# Sync panes (Send input to all panes in the window). When enabled, pane
+# borders become red as an indication.
+bind C-s if -F '#{pane_synchronized}' \
+                     'setw synchronize-panes off; \
+                      setw pane-active-border-style fg=colour63,bg=default; \
+                      setw pane-border-format       " #P "' \
+                   'setw synchronize-panes on; \
+                    setw pane-active-border-style fg=red; \
+                    setw pane-border-format       " #P - Pane Synchronization ON "'
+# Faster command sequence
+set -s escape-time 0
+# Have a very large history
+set -g history-limit 1000000
+# Mouse mode on
+set -g terminal-overrides 'xterm*:smcup@:rmcup@'
+set -g mouse on
+# alacritty bug for clipboard
+set -g set-clipboard off
+# Set title
+set -g set-titles on
+set -g set-titles-string "#T"
+# Equally resize all panes
+bind-key = select-layout even-horizontal
+bind-key | select-layout even-vertical
+# Resize panes
+bind-key J resize-pane -D 10
+bind-key K resize-pane -U 10
+bind-key H resize-pane -L 10
+bind-key L resize-pane -R 10
+# Select panes
+# NOTE(arslan): See to prevent cycling https://github.com/tmux/tmux/issues/1158
+bind-key j select-pane -D
+bind-key k select-pane -U
+bind-key h select-pane -L
+bind-key l select-pane -R
+# Disable confirm before killing
+bind-key x kill-pane
+# This tmux statusbar config was created by tmuxline.vim
+# on Wed, 25 Nov 2015
+set -g status "on"
+set -g status-bg "colour236"
+set -g status-justify "left"
+set -g status-position "top"
+set -g status-left-length "100"
+set -g status-left-style "none"
+set -g status-right-length "100"
+set -g status-right-style "none"
+set -g status-style "none"
+set -g status-left "#{prefix_highlight}#[fg=colour22,bg=colour148,bold] #S #[fg=colour148,bg=colour236,nobold,nounderscore,noitalics]"
+set -g status-right "#[fg=colour240,bg=colour236,nobold,nounderscore,noitalics]#[fg=colour250,bg=colour240] %Y-%m-%d %H:%M #[fg=colour252,bg=colour240,nobold,nounderscore,noitalics]#[fg=colour241,bg=colour252] #h "
+set -g pane-active-border-style fg=colour148
+set -g pane-border-style fg=colour240
+set -g message-style fg=colour231,bg=colour240
+set -g message-command-style fg=colour231,bg=colour240
+setw -g window-status-style fg=colour245,none
+setw -g window-status-activity-style bg=colour236,fg=colour148,none
+setw -g window-status-separator ""
+setw -g window-status-style bg=colour236
+setw -g window-status-format "#[fg=colour245,bg=colour236] #I #[fg=colour245,bg=colour236]#W "
+setw -g window-status-current-format "#[fg=colour236,bg=colour240,nobold,nounderscore,noitalics]#[fg=colour231,bg=colour240] #I #[fg=colour231,bg=colour240]#{?window_zoomed_flag,#[fg=green][],}#W #[fg=colour240,bg=colour236,nobold,nounderscore,noitalics]"
+# List of plugins
+# see this https://github.com/tmux-plugins/tpm to installation
+set -g @plugin 'tmux-plugins/tpm'
+set -g @plugin 'tmux-plugins/tmux-open'
+set -g @plugin 'tmux-plugins/tmux-yank'
+set -g @plugin 'tmux-plugins/tmux-prefix-highlight'
+set -g @plugin 'tmux-plugins/tmux-sensible'
+# Initialize TMUX plugin manager (keep this line at the very bottom of tmux.conf)
+run '~/.tmux/plugins/tpm/tpm'


### PR DESCRIPTION
## Summary

- manage tmux through `~/.config/tmux/tmux.conf` with GNU Stow and a `Ctrl-Space` prefix
- simplify terminal and clipboard integration for Ghostty using native OSC 52 support
- add named session creation and selection shortcuts
- isolate Pi subagent tmux servers with deterministic 0-based indexes and minimal settings
- add sync, safety, and effective tmux configuration tests

## Testing

- `make test`
- verified a fresh `tmux-subagents.sock` server exposes target `0.0` with prefix `C-b`
