### PR TITLE
chore(nvim): temporarily disable copilot plugin

### DIFF
--- a/nvim/.config/nvim/lua/plugins/copilot.lua
+++ b/nvim/.config/nvim/lua/plugins/copilot.lua
@@ -1,5 +1,9 @@
 return {
   {
     'github/copilot.vim',
+    -- Temporarily disabled: the bundled copilot-language-server kept
+    -- crashing with a V8 heap OOM (Aug 2026). Re-enable by removing
+    -- `enabled = false`.
+    enabled = false,
   },
 }


### PR DESCRIPTION
## What

Keep `github/copilot.vim` installed but stop loading it by setting `enabled = false` in `nvim/.config/nvim/lua/plugins/copilot.lua`.

## Why

The bundled `copilot-language-server` repeatedly crashed with a V8 heap OOM (coredump `SIGABRT` in `node::OOMErrorHandler`, memory peak \~4.8 GiB). Crashes observed 2026-08-09, 2026-08-17, and 2026-08-18. This is a temporary disable; the plugin entry is kept so it can be re-enabled by removing `enabled = false`.

Note: `g:copilot_enabled` would not have stopped the server — `copilot.vim` starts it unconditionally on `VimEnter`. `enabled = false` prevents the plugin from loading at all.

## Verification

- Headless nvim run: `loaded_copilot = nil`, no `copilot-language-server` process spawned.